### PR TITLE
soopervisor --skip-docker should use the configured repository when r…

### DIFF
--- a/src/soopervisor/aws/batch.py
+++ b/src/soopervisor/aws/batch.py
@@ -283,7 +283,8 @@ class AWSBatchExporter(abc.AbstractExporter):
                 pkg_name, version = source.find_package_name_and_version()
                 default_image_key = get_default_image_key()
                 if default_image_key:
-                    image_local = f"{pkg_name}:{version}-"
+                    #image_local = f"{pkg_name}:{version}-"
+                    image_local = f"{cfg.repository}:{version}" # use docker image previously created from ECR repository specified in the config file.
                     f"{docker.modify_wildcard(default_image_key)}"
                 image_map = {}
                 image_map[default_image_key] = image_local


### PR DESCRIPTION
soopervisor --skip-docker should use the configured repository whenunning with AWS Batch





## Describe your changes

## Issue ticket number and link
Closes #130 https://github.com/ploomber/soopervisor/issues/130

## Checklist before requesting a review
- [ *] I have performed a self-review of my code
- [* ] I have added thorough tests (when necessary).
- [* ] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

Tested in AWS Batch, earlier it was submitting task using invalid image. Now, it's able to re-use previously created docker image.

```
 $aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin xxx.dkr.ecr.us-west-2.amazonaws.com/prod-repo && soopervisor export deploy --skip-tests --ignore-git --skip-docker
```